### PR TITLE
Resolve lint errors

### DIFF
--- a/app/(auth)/signin.tsx
+++ b/app/(auth)/signin.tsx
@@ -110,7 +110,7 @@ const StensylSigninScreen = () => {
 
           {/* Sign Up Link */}
           <View style={styles.signupContainer}>
-            <Text style={styles.signupText}>Don't have an account? </Text>
+            <Text style={styles.signupText}>Don&apos;t have an account? </Text>
             <Link href={"/signup" as any} asChild>
               {/* Ensure you have an app/signup.tsx file or adjust href */}
               <TouchableOpacity activeOpacity={0.7}>

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -76,8 +76,12 @@ const NotificationItem: React.FC<{ item: NotificationItemData; onPress: () => vo
       <View style={styles.notificationContent}>
         <Text style={styles.notificationText}>
           <Text style={styles.userName}>{item.user.name}</Text> {actionText}.
-          {item.postSnippet && <Text style={styles.snippetText}> "{item.postSnippet}"</Text>}
-          {item.commentSnippet && <Text style={styles.snippetText}> "{item.commentSnippet}"</Text>}
+          {item.postSnippet && (
+            <Text style={styles.snippetText}>&quot;{item.postSnippet}&quot;</Text>
+          )}
+          {item.commentSnippet && (
+            <Text style={styles.snippetText}>&quot;{item.commentSnippet}&quot;</Text>
+          )}
         </Text>
         <Text style={styles.timestamp}>{item.timestamp}</Text>
       </View>

--- a/app/search.tsx
+++ b/app/search.tsx
@@ -168,7 +168,9 @@ const SearchScreen = () => {
           keyExtractor={(item) => item.id}
           ListEmptyComponent={
             <View style={styles.emptyResultsContainer}>
-              <Text style={styles.placeholderText}>No results found for "{searchText}"</Text>
+              <Text style={styles.placeholderText}>
+                No results found for &quot;{searchText}&quot;
+              </Text>
             </View>
           }
           contentContainerStyle={styles.resultsListContainer}


### PR DESCRIPTION
## Summary
- escape unescaped quotes in search results
- escape double quotes in notifications screen
- escape apostrophe in sign-in page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f9c35abe48331b47f8b1c8dcba28e