### PR TITLE
Fix missing loading state in useSessions hook

### DIFF
--- a/hooks/useSessions.ts
+++ b/hooks/useSessions.ts
@@ -4,14 +4,20 @@ import { useCallback, useEffect, useState } from 'react';
 
 export default function useSessions() {
   const [sessions, setSessions] = useState<SessionData[]>([]);
+  const [isLoading, setLoading] = useState(true);
 
   const refresh = useCallback(async () => {
-    setSessions(await getSessions());
+    setLoading(true);
+    try {
+      setSessions(await getSessions());
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => {
-    refresh();           // load on mount
+    refresh(); // load on mount
   }, [refresh]);
 
-  return { sessions, refresh };
+  return { sessions, refresh, isLoading };
 }


### PR DESCRIPTION
## Summary
- add `isLoading` state to `useSessions`

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint/config')*


------
https://chatgpt.com/codex/tasks/task_e_683f9bbdce1c8331ad4b4ba213379497